### PR TITLE
change to CreateApp from CreateDocEx

### DIFF
--- a/access/access.go
+++ b/access/access.go
@@ -34,7 +34,14 @@ func connect(engineURL string, jwtClaims jwt.MapClaims) (*enigma.Global, error) 
 
 // createApp creates an app using the provided Global object and app name.
 func createApp(global *enigma.Global, appName string) (*enigma.Doc, error) {
-	return global.CreateDocEx(ctx, appName, "", "", "", "Main")
+	success, appName, err := global.CreateApp(ctx, appName, "Main")
+	if err != nil {
+		return nil, err
+	}
+	if !success {
+		return nil, errors.New("Failed to create app")
+	}
+	return global.OpenDoc(ctx, appName, "", "", "", false)
 }
 
 // openApp opens an app using the providad Global object and app name.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
 
   empty-engine:
-    image: qlikcore/engine:12.268.0
+    image: qlikcore/engine:12.277.0
     container_name: empty-engine
     restart: always
     command: >
@@ -18,7 +18,7 @@ services:
       - ./rules:/rules
 
   reload-engine:
-    image: qlikcore/engine:12.268.0
+    image: qlikcore/engine:12.277.0
     container_name: reload-engine
     restart: always
     command: >


### PR DESCRIPTION
Changes from `CreateDocEx` to `CreateApp` since `CreateDocEx` is only supposed to work in desktop mode and with `ABAC` engine runs in `Scalable` mode.

Had to make some other minor changes since `CreateApp` does not return the `doc` object as `CreateDocEx` does.