### PR TITLE
bump golang version and add GCC.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine
+FROM golang:1.11-alpine
 
 WORKDIR /go/src/github.com/qlik-oss/core-authorization/
 COPY . /go/src/github.com/qlik-oss/core-authorization/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.11-alpine
 
 WORKDIR /go/src/github.com/qlik-oss/core-authorization/
 COPY . /go/src/github.com/qlik-oss/core-authorization/
-RUN apk add --no-cache curl git && \
+RUN apk add --no-cache curl git gcc && \
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh  && \
     dep ensure
 CMD go test -v ./access

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.11-alpine
 
 WORKDIR /go/src/github.com/qlik-oss/core-authorization/
 COPY . /go/src/github.com/qlik-oss/core-authorization/
-RUN apk add --no-cache curl git gcc && \
+RUN apk add --no-cache curl git gcc musl-dev && \
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh  && \
     dep ensure
 CMD go test -v ./access


### PR DESCRIPTION
The `golang:1.11-alpine` removes `gcc` which one of our dependencies requires to compile.

This PR bumps the version and adds back gcc and its dependency